### PR TITLE
fix: chose correct extension on file creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed extension name in VSCode settings
+
+## [1.0.3] - 2024-10-09
+
+### Changed
+
+- Fixed issue where selecting '.jsx' in settings would still create '.tsx' files

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-compgenie",
   "displayName": "React Component Genie",
   "description": "Generate React/React Native components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "GPL-3.0-only",
   "publisher": "nyukeit",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,8 @@ export function activate(context: vscode.ExtensionContext) {
 
         // Read the default extension from the configuration
         const config = vscode.workspace.getConfiguration();
-        const defaultExtension = config.get<string>('reactComponentCreator.defaultExtension') || '.tsx';
+        const defaultExtension = config.get<string>('reactComponentGenie.defaultExtension') || '.tsx';
+        console.log(defaultExtension);
 
         // Ask the user for the folder path and component name
         const componentPath = await vscode.window.showInputBox({


### PR DESCRIPTION
- Fixed issue where selecting '.jsx' in settings would still create '.tsx' files